### PR TITLE
Some tidying

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,3 @@
-
 use clap::Parser;
 
 #[derive(Parser, Debug)]

--- a/src/genetic_data.rs
+++ b/src/genetic_data.rs
@@ -59,7 +59,7 @@ pub fn create_genetic_data(
     filename: &str,
     topology: &Topology,
     rate_matrix: &na::Matrix4<f64>,
-) -> ndarray::ArrayBase<ndarray::OwnedRepr<f64>, ndarray::Dim<[usize; 3]>> {
+) -> ndarray::Array3<f64> {
     // Count number of sequences and their length
     let mut n_seqs = 0;
     let mut n_bases = 0;
@@ -70,8 +70,7 @@ pub fn create_genetic_data(
         n_bases = seqrec.num_bases();
     }
     // Create pre-filled array
-    let mut gen_data: ndarray::ArrayBase<ndarray::OwnedRepr<f64>, ndarray::Dim<[usize; 3]>> =
-        ndarray::Array3::from_elem((2 * n_seqs - 1, n_bases, 4), -99.0);
+    let mut gen_data = ndarray::Array3::from_elem((2 * n_seqs - 1, n_bases, 4), -99.0);
     // println!("Assigning data for {} leaves and {} total nodes", n_seqs, (2 * n_seqs) + 1);
 
     let mut reader2 = parse_fastx_file(filename).expect("Error parsing file");
@@ -91,10 +90,10 @@ pub fn create_genetic_data(
 }
 
 pub fn create_internal_data(
-    mut data: ndarray::ArrayBase<ndarray::OwnedRepr<f64>, ndarray::Dim<[usize; 3]>>,
+    mut data: ndarray::Array3<f64>,
     topology: &Topology,
     rate_matrix: &na::Matrix4<f64>,
-) -> ndarray::ArrayBase<ndarray::OwnedRepr<f64>, ndarray::Dim<[usize; 3]>> {
+) -> ndarray::Array3<f64> {
     // Iterate over internal nodes postorder
     let nodes = topology.postorder_notips(topology.get_root());
 
@@ -122,11 +121,10 @@ pub fn create_dummy_gendata(
     n_bases: usize,
     topology: &Topology,
     rate_matrix: &na::Matrix4<f64>,
-) -> ndarray::ArrayBase<ndarray::OwnedRepr<f64>, ndarray::Dim<[usize; 3]>> {
+) -> ndarray::Array3<f64> {
     let n_seqs = topology.count_leaves();
 
-    let mut gen_data: ndarray::ArrayBase<ndarray::OwnedRepr<f64>, ndarray::Dim<[usize; 3]>> =
-        ndarray::Array3::from_elem(((2 * n_seqs) + 1, n_bases, 4), 0.0);
+    let mut gen_data = ndarray::Array3::from_elem(((2 * n_seqs) + 1, n_bases, 4), 0.0);
 
     let mut rng = thread_rng();
 
@@ -142,7 +140,7 @@ pub fn create_dummy_gendata(
 
 pub fn child_likelihood_i(
     i: usize,
-    ll: ndarray::ArrayBase<ndarray::ViewRepr<&f64>, ndarray::Dim<[usize; 1]>>,
+    ll: ndarray::ArrayView1<f64>,
     p: &na::Matrix4<f64>,
 ) -> f64 {
     p.row(i)
@@ -158,11 +156,11 @@ pub fn matrix_exp(rate_matrix: &na::Matrix4<f64>, branch_len: f64) -> na::Matrix
 }
 
 pub fn node_likelihood(
-    seql: ndarray::ArrayBase<ndarray::ViewRepr<&f64>, ndarray::Dim<[usize; 2]>>,
-    seqr: ndarray::ArrayBase<ndarray::ViewRepr<&f64>, ndarray::Dim<[usize; 2]>>,
+    seql: ndarray::ArrayView2<f64>,
+    seqr: ndarray::ArrayView2<f64>,
     matrixl: &na::Matrix4<f64>,
     matrixr: &na::Matrix4<f64>,
-) -> ndarray::ArrayBase<ndarray::OwnedRepr<f64>, ndarray::Dim<[usize; 2]>> {
+) -> ndarray::Array2<f64> {
     let out = ndarray::Array2::from_shape_fn((seql.dim().0, 4), |(i, j)| {
         child_likelihood_i(j, seql.slice(s![i, ..]), matrixl)
             + child_likelihood_i(j, seqr.slice(s![i, ..]), matrixr)
@@ -174,7 +172,7 @@ pub fn node_likelihood(
 pub const BF_DEFAULT: [f64; 4] = [0.25, 0.25, 0.25, 0.25];
 
 pub fn base_freq_logse(
-    muta: ndarray::ArrayBase<ndarray::ViewRepr<&f64>, ndarray::Dim<[usize; 1]>>,
+    muta: ndarray::ArrayView1<f64>,
     bf: [f64; 4],
 ) -> f64 {
     muta.iter()

--- a/src/genetic_data.rs
+++ b/src/genetic_data.rs
@@ -3,9 +3,6 @@ use logaddexp::LogAddExp;
 use ndarray::s;
 use needletail::parse_fastx_file;
 use rand::{thread_rng, Rng};
-use std::collections::HashMap;
-use std::os::unix::thread;
-use std::thread::current;
 
 const NEGINF: f64 = -f64::INFINITY;
 // (A, C, G, T)
@@ -48,7 +45,7 @@ pub fn char_to_likelihood(e: &char) -> [f64; 4] {
 
 pub fn count_sequences(filename: &str) -> usize {
     let mut reader = parse_fastx_file(filename).expect("Error parsing file");
-    let mut n_seqs: usize = 0;
+    let mut n_seqs = 0;
     while let Some(_record) = reader.next() {
         n_seqs += 1;
     }

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -50,7 +50,7 @@ impl<'a> Iterator for PostOrderIter<'a> {
 }
 
 impl Topology {
-    pub fn postorder<'a>(&'a self, node: &'a NodeTuple) -> PostOrderIter {
+    pub fn postorder<'a>(&'a self, node: &'a NodeTuple) -> PostOrderIter<'a> {
         PostOrderIter {
             current_node: node,
             start_flag: true,
@@ -59,12 +59,12 @@ impl Topology {
         }
     }
 
-    pub fn postorder_notips<'a>(&'a self, node: &'a NodeTuple) -> impl Iterator<Item = &NodeTuple> {
+    pub fn postorder_notips<'a>(&'a self, node: &'a NodeTuple) -> impl Iterator<Item = &'a NodeTuple> {
         self.postorder(node)
             .filter(|node| node.get_lchild().is_some() && node.get_rchild().is_some())
     }
 
-    pub fn most_left_child<'a>(&'a self, node: &'a NodeTuple) -> &NodeTuple {
+    pub fn most_left_child<'a>(&'a self, node: &'a NodeTuple) -> &'a NodeTuple {
         let mut current_node = node;
         let mut current_left_child = self.get_lchild(current_node);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,6 @@ use rate_matrix::RateMatrix;
 use topology::Topology;
 use treestate::*;
 // use treestate::{TreeState, hillclimb_accept, always_accept};
-use rand::distributions::Distribution;
 
 use crate::newick_to_vec::*;
 extern crate nalgebra as na;
@@ -22,13 +21,10 @@ use crate::cli::*;
 use crate::genetic_data::*;
 use crate::moves::*;
 use crate::topology::from_vec;
-use crate::topology::NodeTuple;
-use ndarray::s;
 use std::time::Instant;
 
 pub fn main() {
     let args = cli_args();
-    let start = Instant::now();
 
     // let mut tr = vector_to_tree(&random_vector(4));
     // tr.add_genetic_data(&String::from("/Users/joel/Downloads/listeria0.aln"));

--- a/src/moves.rs
+++ b/src/moves.rs
@@ -1,12 +1,9 @@
-use std::collections::HashMap;
-
 use crate::newick_to_vector;
 // use crate::treestate::TreeMove;
 use crate::topology::from_vec;
 use crate::RateMatrix;
 use crate::Topology;
 use crate::TreeState;
-use rand::prelude::Distribution;
 use rand::Rng;
 
 pub struct ExactMove {
@@ -26,7 +23,7 @@ impl<R: RateMatrix> TreeMove<R> for ExactMove {
         current_treestate: &TreeState<R>,
     ) -> (Option<Topology>, Option<R>, Option<Vec<usize>>) {
         let new_topology = from_vec(&self.target_vector);
-        let changes: Option<Vec<usize>> = current_treestate.top.find_changes(&new_topology);
+        let changes = current_treestate.top.find_changes(&new_topology);
         (Some(new_topology), None, changes)
     }
 }
@@ -44,7 +41,7 @@ impl<R: RateMatrix> TreeMove<R> for PeturbVec {
         let distr = rand::distributions::Bernoulli::new(0.5).unwrap();
         let ind_distr = rand::distributions::Uniform::new(0, vout.len());
 
-        let samp_n: usize = match self.n.gt(&vout.len()) {
+        let samp_n = match self.n.gt(&vout.len()) {
             true => vout.len(),
             false => self.n,
         };
@@ -71,8 +68,8 @@ impl<R: RateMatrix> TreeMove<R> for PeturbVec {
             };
         }
 
-        let new_topology: Topology = from_vec(&vout);
-        let changes: Option<Vec<usize>> = ts.top.find_changes(&new_topology);
+        let new_topology = from_vec(&vout);
+        let changes = ts.top.find_changes(&new_topology);
         (Some(new_topology), None, changes)
     }
 }
@@ -82,7 +79,7 @@ pub struct ChildSwap {}
 impl<R: RateMatrix> TreeMove<R> for ChildSwap {
     fn generate(&self, ts: &TreeState<R>) -> (Option<Topology>, Option<R>, Option<Vec<usize>>) {
         // Create new topology
-        let mut new_topology: Topology = Topology {
+        let mut new_topology = Topology {
             nodes: ts.top.nodes.clone(),
             tree_vec: ts.top.tree_vec.clone(),
         };

--- a/src/newick_to_vec.rs
+++ b/src/newick_to_vec.rs
@@ -27,17 +27,12 @@ pub mod ffi {
 // Create a random vector with a given length //
 ////////////////////////////////////////////////
 pub fn random_vector(n_seqs: usize) -> Vec<usize> {
-    let mut rng = rand::thread_rng();
-
-    vec![0; n_seqs]
-        .iter()
-        .enumerate()
-        .map(|(i, _el)| {
-            if i > 0 {
-                rng.gen_range(0..((2 * i) - 1))
-            } else {
-                0
-            }
-        })
-        .collect()
+    (0..n_seqs).map(|i| {
+        if i > 0 {
+            rand::thread_rng().gen_range(0..((2 * i) - 1))
+        } else {
+            0
+        }
+    })
+    .collect()
 }

--- a/src/rate_matrix.rs
+++ b/src/rate_matrix.rs
@@ -1,4 +1,4 @@
-use crate::topology::Topology;
+//use crate::topology::Topology;
 use rand::distributions::{Distribution, Uniform};
 use statrs::distribution::Dirichlet;
 // use crate::TreeState;
@@ -187,7 +187,7 @@ impl RateMatrix for Jc69 {
     fn matrix_move(&self) -> Self {
         let dist = Uniform::new(0.0, 1.0);
         let params = vec![dist.sample(&mut rand::thread_rng())];
-        let mut new: Self = Self::default();
+        let mut new = Self::default();
         new.update_params(params);
         new.update_matrix();
         new

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -14,7 +14,7 @@ use crate::TreeState;
 #[test]
 fn check_topology_build_manual() {
     // I check that new topologies have the correct parent by comparing to known parent values
-    let mut top: Topology = from_vec(&[0, 0, 0, 0]);
+    let mut top = from_vec(&[0, 0, 0, 0]);
 
     assert_eq!(top.nodes[0].get_parent(), Some(4));
     assert_eq!(top.nodes[0].get_parent(), Some(4));
@@ -100,7 +100,7 @@ fn update_tree() {
         likelihood: ll,
     };
 
-    let vecs: Vec<Vec<usize>> = vec![
+    let vecs = vec![
         vec![0, 0, 0, 0],
         vec![0, 0, 1, 0],
         vec![0, 0, 1, 2],
@@ -154,7 +154,7 @@ fn likelihood_internal_consistency_check() {
 
 #[test]
 fn manual_parent_check() {
-    let top: Topology = from_vec(&[0, 0, 0, 0]);
+    let top = from_vec(&[0, 0, 0, 0]);
     // Newick string for this tree is (1,(2,(3,0)4)5)6;
     // This should be the tree topology according to the ape package in R
     assert_eq!(
@@ -170,7 +170,7 @@ fn manual_parent_check() {
         (Some(5), Some(1))
     );
 
-    let top: Topology = from_vec(&[0, 0, 0, 1]);
+    let top = from_vec(&[0, 0, 0, 1]);
     // Newick string for this tree is ((3,1)4,(2,0)5)6;
     // This should be the tree topology according to the ape package in R
     assert_eq!(
@@ -186,7 +186,7 @@ fn manual_parent_check() {
         (Some(5), Some(4))
     );
 
-    let top: Topology = from_vec(&[0, 0, 1, 1]);
+    let top = from_vec(&[0, 0, 1, 1]);
     // Newick string for this tree is ((2,(3,1)4)5,0)6;
     // This should be the tree topology according to the ape package in R
     assert_eq!(
@@ -202,7 +202,7 @@ fn manual_parent_check() {
         (Some(0), Some(5))
     );
 
-    let top: Topology = from_vec(&[0, 0, 1, 1, 3]);
+    let top = from_vec(&[0, 0, 1, 1, 3]);
     // Newick string for this tree is ((2,((4,3)5,1)6)7,0)8;
     // This should be the tree topology according to the ape package in R
     assert_eq!(
@@ -230,7 +230,7 @@ fn manual_parent_check() {
 #[test]
 fn newick_vector_conversion_check() {
     let v = random_vector(27);
-    let top: Topology = from_vec(&v);
+    let top = from_vec(&v);
     let nw = top.get_newick();
     let n_leaves = top.count_leaves();
     let y = newick_to_vector(&nw, n_leaves);

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -376,7 +376,7 @@ impl Topology {
 
     pub fn likelihood(
         &self,
-        gen_data: &ndarray::ArrayBase<ndarray::OwnedRepr<f64>, ndarray::Dim<[usize; 3]>>,
+        gen_data: &ndarray::Array3<f64>,
     ) -> f64 {
         let root_likelihood = gen_data.slice(s![self.get_root().get_id(), .., ..]);
 

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -91,9 +91,9 @@ pub fn from_vec(tree_vec: &[usize]) -> Topology {
     let mut sub_vec = tree_vec.to_vec();
     sub_vec.remove(0);
     let k = sub_vec.len();
-    let mut not_processed = [true].repeat(k);
-    let mut M = Array2::<usize>::zeros((k, 3));
-    let mut labels = Array2::<usize>::zeros((k + 1, k + 1));
+    let mut not_processed = vec![true; k];
+    let mut M = Array2::zeros((k, 3));
+    let mut labels = Array2::zeros((k + 1, k + 1));
 
     for i in 0..=k {
         for j in 0..=k {
@@ -155,17 +155,17 @@ pub fn from_vec(tree_vec: &[usize]) -> Topology {
 
 // Builds a new Topology from a Newick String
 pub fn from_newick(rjstr: String) -> Vec<NodeTuple> {
-    let mut new_str: String = rjstr.clone();
+    let mut new_str = rjstr.clone();
     let full_split: Vec<&str> = rjstr
         .split(['(', ',', ')', ';'])
         .filter(|c| !c.is_empty())
         .collect();
-    let mut label_dictionary: HashMap<usize, String> = HashMap::with_capacity(full_split.len());
-    let mut branch_length: HashMap<usize, f64> = HashMap::with_capacity(full_split.len());
+    let mut label_dictionary = HashMap::with_capacity(full_split.len());
+    let mut branch_length = HashMap::with_capacity(full_split.len());
     let mut bl: f64;
-    let mut leaf_idx: usize = 0;
-    let mut internal_idx: usize = ((full_split.len() + 1) / 2) + 1;
-    let mut idx: usize;
+    let mut leaf_idx = 0;
+    let mut internal_idx = ((full_split.len() + 1) / 2) + 1;
+    let mut idx;
 
     for (i, x) in full_split.iter().enumerate() {
         // Split this node into (possibly non-existant) label and branch length
@@ -197,7 +197,7 @@ pub fn from_newick(rjstr: String) -> Vec<NodeTuple> {
     let firstcom = new_str.rfind(',').unwrap();
     new_str.insert(firstcom, ')');
     // Give an internal node label after this new bracket
-    let mut nstr: String = [
+    let mut nstr = [
         &new_str[0..=firstcom],
         &internal_idx.to_string(),
         &new_str[firstcom + 1..new_str.len()],
@@ -213,9 +213,9 @@ pub fn from_newick(rjstr: String) -> Vec<NodeTuple> {
 
     // This section goes through the Newick string and records the parent nodes of each node
     // so that we can build a Tree struct
-    let mut current_parent: Option<usize> = None;
-    let mut parent_vector: Vec<Option<usize>> = vec![None; internal_idx + 1];
-    let mut idx: Option<usize> = Some(internal_idx);
+    let mut current_parent = None;
+    let mut parent_vector = vec![None; internal_idx + 1];
+    let mut idx = Some(internal_idx);
 
     for i in (1..nstr.len()).rev() {
         let ch: char = nstr.chars().nth(i).unwrap();
@@ -226,14 +226,14 @@ pub fn from_newick(rjstr: String) -> Vec<NodeTuple> {
             }
 
             let mut j = i - 1;
-            let mut jch: char = nstr.chars().nth(j).unwrap();
+            let mut jch = nstr.chars().nth(j).unwrap();
             while j > 0 && jch.ne(&'(') && jch.ne(&',') && jch.ne(&')') {
                 j -= 1;
                 jch = nstr.chars().nth(j).unwrap();
             }
 
             if j != (i - 1) {
-                let leaf: &str = &nstr[(j + 1)..i];
+                let leaf = &nstr[(j + 1)..i];
                 idx = Some(leaf.parse().unwrap());
                 parent_vector[idx.unwrap()] = current_parent;
             }
@@ -243,7 +243,7 @@ pub fn from_newick(rjstr: String) -> Vec<NodeTuple> {
     }
 
     // Add nodes to Tree from parent vector, give correct branch length
-    let mut nodevec: Vec<NodeTuple> =
+    let mut nodevec =
         vec![NodeTuple(0, None, None, None, 0.0, 0); internal_idx + 1];
 
     for (i, parent) in parent_vector.iter().enumerate().rev() {
@@ -265,10 +265,10 @@ pub fn from_newick(rjstr: String) -> Vec<NodeTuple> {
 impl Topology {
     // Builds a Newick String for a Topology object
     pub fn get_newick(&self) -> String {
-        let mut current_node: Option<&NodeTuple> = Some(self.get_root());
-        let mut next_node: Option<&NodeTuple>;
-        let mut return_nodes: Vec<Option<&NodeTuple>> = Vec::new();
-        let mut newick: Vec<String> = vec![
+        let mut current_node = Some(self.get_root());
+        let mut next_node;
+        let mut return_nodes = Vec::new();
+        let mut newick = vec![
             String::from(";"),
             current_node.unwrap().get_branchlen().to_string(),
             String::from(":"),
@@ -304,7 +304,7 @@ impl Topology {
                         Some(a) => a,
                     };
                     if next_node.is_some() {
-                        let n: usize =
+                        let n =
                             current_node.unwrap().get_depth() - next_node.unwrap().get_depth();
                         match n {
                             0 => {
@@ -322,7 +322,7 @@ impl Topology {
                         newick.push(String::from(":"));
                         newick.push(next_node.unwrap().get_id().to_string());
                     } else {
-                        let n: usize = current_node.unwrap().get_depth();
+                        let n = current_node.unwrap().get_depth();
                         for _ in 1..=n {
                             newick.push(String::from("("));
                         }

--- a/src/treestate.rs
+++ b/src/treestate.rs
@@ -1,15 +1,8 @@
-use crate::iterators::ChangeIter;
-use crate::rate_matrix;
-use crate::topology;
-use crate::topology::from_vec;
-use crate::topology::NodeTuple;
 use crate::RateMatrix;
 use crate::Topology;
 use crate::TreeMove;
 use crate::{base_freq_logse, matrix_exp, node_likelihood, BF_DEFAULT};
 use std::collections::HashMap;
-use std::hash::Hash;
-// use crate::ExactMove;
 use ndarray::s;
 
 pub struct TreeState<R: RateMatrix> {

--- a/src/treestate.rs
+++ b/src/treestate.rs
@@ -22,7 +22,7 @@ pub fn apply_move<M: TreeMove<R>, R: RateMatrix>(
     current_ts: TreeState<R>,
     move_fn: M,
     accept_fn: fn(&f64, &f64) -> bool,
-    gen_data: &mut ndarray::ArrayBase<ndarray::OwnedRepr<f64>, ndarray::Dim<[usize; 3]>>,
+    gen_data: &mut ndarray::Array3<f64>,
 ) -> TreeState<R> {
     let (new_topology, new_mat, changes) = move_fn.generate(&current_ts);
 
@@ -44,7 +44,7 @@ pub fn apply_move<M: TreeMove<R>, R: RateMatrix>(
 
     let mut temp_likelihoods: HashMap<
         usize,
-        ndarray::ArrayBase<ndarray::OwnedRepr<f64>, ndarray::Dim<[usize; 2]>>,
+        ndarray::Array2<f64>,
     > = HashMap::new();
 
     for node in nodes_to_update {


### PR DESCRIPTION
Just a bunch of small changes including:
* using the nice type aliases that `ndarray` provides instead of writing out the full types using `ArrayBase<...>`
* removing unnecessary type annotations
* removing some unused imports
* fixing some lifetime warnings
* simplifying the `random_vector` function